### PR TITLE
Replace strftime() with date() for PHP 8.1 compatibility

### DIFF
--- a/src/NuSoap.php
+++ b/src/NuSoap.php
@@ -983,7 +983,7 @@ class NuSoap
             $usec = 0;
         }
 
-        return strftime('%Y-%m-%d %H:%M:%S', $sec) . '.' . sprintf('%06d', $usec);
+        return date('Y-m-d H:i:s', $sec) . '.' . sprintf('%06d', $usec);
     }
 
     /**


### PR DESCRIPTION
and to prevent deprecation warnings in previous versions.